### PR TITLE
Add BoringToolsKit Marketplace Fee Calculators (Calculators)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 📈 361 Awesome Investing Tools & Software for Investors
+# 📈 362 Awesome Investing Tools & Software for Investors
 
 > A practical, editorially curated directory of investing research tools, datasets, brokers, APIs, calculators, and communities.
 
@@ -33,6 +33,7 @@ Last refreshed **August 15, 2026** from the Find My Moat research catalog.
 | [🧮 Calculators](#-calculators) | 2 |
 | [📡 Market Data, News and Alerts](#-market-data-news-and-alerts) | 36 |
 | [📊 Research and Valuation](#-research-and-valuation) | 40 |
+| [✨ Other](#-other) | 1 |
 
 ---
 
@@ -490,6 +491,14 @@ Last refreshed **August 15, 2026** from the Find My Moat research catalog.
 - [Visible Alpha](https://www.spglobal.com/market-intelligence/en/solutions/visible-alpha) — Visible Alpha, now part of S&P Global Market Intelligence, is an enterprise consensus and model-derived data platform built from full sell-side analyst models. It is useful for line-item estimates, segment/KPI… ([research profile](https://www.findmymoat.com/tools/visible-alpha?utm_source=github&utm_medium=referral&utm_campaign=awesome_investing_tools&utm_content=visible-alpha))
 - [Visual Capitalist](https://www.visualcapitalist.com) — Visual Capitalist is a publisher of data-rich infographics and explainers covering markets, commodities, technology, macroeconomics, and global business themes. It is strongest as visual context for research and… ([research profile](https://www.findmymoat.com/tools/visual-capitalist?utm_source=github&utm_medium=referral&utm_campaign=awesome_investing_tools&utm_content=visual-capitalist))
 - [Winus](https://www.winus.ai) — Winus is an AI-assisted financial research workspace for stock, market, macro, and cross-asset analysis. It is best evaluated as a source-traceable research assistant for finance professionals, not as a broker,… ([research profile](https://www.findmymoat.com/tools/winus?utm_source=github&utm_medium=referral&utm_campaign=awesome_investing_tools&utm_content=winus))
+
+[Back to contents](#contents)
+
+---
+
+### ✨ Other
+
+- [BoringToolsKit Marketplace Fee Calculators](https://boringtoolskit.com/ebay-fee-profit-calculator/) — Free browser calculators that compute what eBay, Etsy, Amazon, and Shopify take from a marketplace sale, plus the break-even sale price after platform fees and shipping. Includes break-even profit margins and net…
 
 [Back to contents](#contents)
 

--- a/data/community-tools.json
+++ b/data/community-tools.json
@@ -1,1 +1,10 @@
-[]
+[
+  {
+    "name": "BoringToolsKit Marketplace Fee Calculators",
+    "url": "https://boringtoolskit.com/ebay-fee-profit-calculator/",
+    "categories": [
+      "Calculators"
+    ],
+    "summary": "Free browser calculators that compute what eBay, Etsy, Amazon, and Shopify take from a marketplace sale, plus the break-even sale price after platform fees and shipping. Includes break-even profit margins and net proceeds for sellers; runs client-side with no sign-up."
+  }
+]


### PR DESCRIPTION
Adds one tool to **Calculators** via `data/community-tools.json` + rebuilt README (`node scripts/build-directory.mjs`), per CONTRIBUTING.

**Tool:** [BoringToolsKit Marketplace Fee Calculators](https://boringtoolskit.com/ebay-fee-profit-calculator/) — free, client-side calculators computing what eBay, Etsy, Amazon, and Shopify take from a marketplace sale: all-in platform fees, effective rate, net proceeds, break-even sale price after fees and shipping.

**Investor job it helps complete:** marketplace selling is an income stream many investors track alongside portfolios; this quantifies the fee drag on that income and the pricing floor needed to stay profitable — comparable to the fee-awareness angle of the existing Calculators entries.

**Disclosure:** I own and built this tool. Available now, public website, no waitlist. Data behind the calculators is published openly ([Marketplace Fee Index 2026](https://github.com/roadtogideon222-byte/btk-data)) with a [verifiable test suite](https://github.com/roadtogideon222-byte/boringtoolskit-calculation-tests).
